### PR TITLE
Feature/security Spring Security + Kakao OAuth + 자체 JWT 로그인 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
       <artifactId>commons-codec</artifactId>
       <version>1.16.0</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11 -->
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc11</artifactId>
@@ -185,10 +186,11 @@
       <artifactId>commons-fileupload</artifactId>
       <version>1.5</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -271,6 +273,8 @@
       <artifactId>spring-tx</artifactId>
       <version>3.0.5.RELEASE</version>
     </dependency>
+
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/livarter/app/config/CorsConfig.java
+++ b/src/main/java/com/livarter/app/config/CorsConfig.java
@@ -1,0 +1,28 @@
+package com.livarter.app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+/**
+ * @author : 황수영
+ * @fileName : CorsConfig
+ * @since : 2024-01-21
+ */
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/livarter/app/config/RootContextConfig.java
+++ b/src/main/java/com/livarter/app/config/RootContextConfig.java
@@ -5,9 +5,8 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
@@ -24,6 +23,7 @@ import javax.sql.DataSource;
  */
 @Configuration
 @MapperScan(value = "com.livarter.app.mapper")
+@PropertySource("classpath:application.properties")
 public class RootContextConfig {
 
     @Value("${database.username}")
@@ -34,9 +34,6 @@ public class RootContextConfig {
 
     @Value("${database.url}")
     private String url;
-
-    @Autowired
-    private ApplicationContext applicationContext;
 
     @Bean
     public SqlSessionTemplate sqlSessionTemplate() throws Exception {

--- a/src/main/java/com/livarter/app/config/SecurityConfig.java
+++ b/src/main/java/com/livarter/app/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package com.livarter.app.config;
+
+import com.livarter.app.security.AuthTokenAccessDeniedHandler;
+import com.livarter.app.security.AuthTokenAuthenticationEntryPoint;
+import com.livarter.app.security.AuthTokenFilterConfigurer;
+import com.livarter.app.security.AuthTokenGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * @author : 황수영
+ * @fileName : SecurityConfig
+ * @since : 2024-01-19
+ */
+@Log4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final AuthTokenGenerator authTokenGenerator;
+    private final AuthTokenAccessDeniedHandler authTokenAccessDeniedHandler;
+    private final AuthTokenAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    public void configure(WebSecurity web) {
+        web.ignoring()
+                .antMatchers("/resources/**", "/", "/api/v1/auth/**");
+    }
+    @Override
+    public void configure(HttpSecurity httpSecurity) throws Exception {
+
+        httpSecurity
+                    .csrf().disable()
+                    .sessionManagement()
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                    .headers()
+                    .httpStrictTransportSecurity().disable()
+                .and()
+                    .exceptionHandling()
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .and()
+                    .exceptionHandling()
+                    .accessDeniedHandler(authTokenAccessDeniedHandler)
+                    .and()
+                    .authorizeRequests()
+                    .antMatchers("/api/v1/auth/**").permitAll()
+                    .antMatchers("/api/v1/member/**").authenticated()
+                //.antMatchers("/api/v1/member/**").hasRole("MEMBER") // 이후에 멤버만 허용
+                    .anyRequest().permitAll()
+                .and()
+                    .apply(new AuthTokenFilterConfigurer(authTokenGenerator));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/livarter/app/config/WebConfig.java
+++ b/src/main/java/com/livarter/app/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.livarter.app.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
@@ -16,6 +15,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     @Override
     protected Class<?>[] getRootConfigClasses() {
         return new Class[] {
+                SecurityConfig.class,
                 RootContextConfig.class,
                 AopConfig.class
         };
@@ -24,7 +24,8 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     @Override
     protected Class<?>[] getServletConfigClasses() {
         return new Class[] {
-                ServletContextConfig.class
+                ServletContextConfig.class,
+                CorsConfig.class
         };
     }
 
@@ -35,14 +36,11 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
 
     @Override
     protected Filter[] getServletFilters() {
-        return new Filter[] { characterEncodingFilter() };
-    }
+        CharacterEncodingFilter characterEncodingFilter
+                = new CharacterEncodingFilter();
+        characterEncodingFilter.setEncoding("UTF-8");
+        characterEncodingFilter.setForceEncoding(true);
 
-    @Bean
-    public Filter characterEncodingFilter() {
-        CharacterEncodingFilter filter = new CharacterEncodingFilter();
-        filter.setEncoding("UTF-8");
-        filter.setForceEncoding(true);
-        return filter;
+        return new Filter[] { characterEncodingFilter };
     }
 }

--- a/src/main/java/com/livarter/app/controller/AuthController.java
+++ b/src/main/java/com/livarter/app/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.livarter.app.controller;
+
+import com.livarter.app.security.dto.LoginReqDto;
+import com.livarter.app.security.dto.LoginResDto;
+import com.livarter.app.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author : 황수영
+ * @fileName : AuthController
+ * @since : 2024-01-19
+ */
+@Log4j
+@RequestMapping("/api/v1/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberService memberService;
+
+    @PostMapping(value = "/login")
+    public ResponseEntity<LoginResDto> testLogin(@RequestBody LoginReqDto loginReqDto) {
+        LoginResDto loginResDto = memberService.login(loginReqDto);
+        log.debug("이메일로 회원가입 - 로그인 토큰 : " + loginReqDto.getLoginToken());
+        log.debug("tokenDto : " + loginResDto.getAccessToken());
+        return new ResponseEntity<>(loginResDto, HttpStatus.ACCEPTED);
+    }
+}

--- a/src/main/java/com/livarter/app/controller/MemberController.java
+++ b/src/main/java/com/livarter/app/controller/MemberController.java
@@ -1,0 +1,32 @@
+package com.livarter.app.controller;
+
+import com.livarter.app.dto.MemberResDto;
+import com.livarter.app.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * @author : 황수영
+ * @fileName : MemberController
+ * @since : 2024-01-21
+ */
+
+@Log4j
+@RequestMapping("/api/v1/member")
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<MemberResDto> getMember(Authentication authentication) {
+        log.debug("회원 정보 조회 : " + authentication.getName());
+        MemberResDto memberResDto = memberService.getMember(authentication.getName());
+        return new ResponseEntity<>(memberResDto, HttpStatus.ACCEPTED);
+    }
+}

--- a/src/main/java/com/livarter/app/domain/Member.java
+++ b/src/main/java/com/livarter/app/domain/Member.java
@@ -1,0 +1,43 @@
+package com.livarter.app.domain;
+
+import com.livarter.app.domain.enumType.Grade;
+import com.livarter.app.domain.enumType.Role;
+import lombok.*;
+
+import java.time.LocalDate;
+
+/**
+ * @author : 황수영
+ * @fileName : Member
+ * @since : 2024-01-19
+ */
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    private int id;
+    private String email;
+    private String nickname;
+    private Role role;
+
+    private String image;
+    private String refreshToken;
+    private Grade grade;
+
+    private String name;
+    private String address;
+    private String zipCode;
+    private LocalDate birthDate;
+
+    private int curPoint;
+    private int totalPoint;
+    private LocalDate createdAt;
+    private LocalDate updatedAt;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/livarter/app/domain/enumType/Grade.java
+++ b/src/main/java/com/livarter/app/domain/enumType/Grade.java
@@ -1,0 +1,22 @@
+package com.livarter.app.domain.enumType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author : 황수영
+ * @fileName : MembershipLevel
+ * @since : 2024-01-20
+ */
+
+@Getter
+@AllArgsConstructor
+public enum Grade {
+    BEGINNER(1, 1, 0),
+    ARTIEST(3, 3, 30_000),
+    LIVARTIEST(5, 5, 100_000);
+
+    private final int discountRate; // 할인 비율
+    private final int savingRate;   // 포인트 적립 비율
+    private final int minPoint;     // 해당 등급으로 올라가는 최저 포인트
+}

--- a/src/main/java/com/livarter/app/domain/enumType/Header.java
+++ b/src/main/java/com/livarter/app/domain/enumType/Header.java
@@ -1,0 +1,17 @@
+package com.livarter.app.domain.enumType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author : 황수영
+ * @fileName : Header
+ * @since : 2024-01-22
+ */
+@Getter
+@AllArgsConstructor
+public enum Header {
+    AUTH("Authorization"),
+    BEARER("Bearer ");
+    private final String value;
+}

--- a/src/main/java/com/livarter/app/domain/enumType/Nickname.java
+++ b/src/main/java/com/livarter/app/domain/enumType/Nickname.java
@@ -1,0 +1,36 @@
+package com.livarter.app.domain.enumType;
+
+import lombok.Getter;
+
+import java.util.Random;
+
+/**
+ * @author : 황수영
+ * @fileName : Nickname
+ * @since : 2024-01-20
+ */
+@Getter
+public enum Nickname {
+
+    DESCRIPTORS("자유로운 ", "안목있는 ", "힙한 ", "신중한 ", "귀여운 ", "센스있는 "),
+    NAME("가구 수집가", "조명 수집가", "아티스트");
+
+    private final String[] words;
+    private static final Random random = new Random();
+
+    Nickname(String... words) {
+        this.words = words;
+    }
+
+    public static String getRandomNickname() {
+        StringBuilder randomNickname = new StringBuilder();
+        return randomNickname.append(getRandomWord(DESCRIPTORS.words))
+                .append(getRandomWord(NAME.words))
+                .toString();
+    }
+
+    private static String getRandomWord(String[] words)  {
+        int index = random.nextInt(words.length);
+        return words[index];
+    }
+}

--- a/src/main/java/com/livarter/app/domain/enumType/OAuthType.java
+++ b/src/main/java/com/livarter/app/domain/enumType/OAuthType.java
@@ -1,0 +1,13 @@
+package com.livarter.app.domain.enumType;
+
+import lombok.Getter;
+
+/**
+ * @author : 황수영
+ * @fileName : OAuthType
+ * @since : 2024-01-20
+ */
+@Getter
+public enum OAuthType {
+    KAKAO;
+}

--- a/src/main/java/com/livarter/app/domain/enumType/Role.java
+++ b/src/main/java/com/livarter/app/domain/enumType/Role.java
@@ -1,0 +1,13 @@
+package com.livarter.app.domain.enumType;
+
+import lombok.Getter;
+
+/**
+ * @author : 황수영
+ * @fileName : Role
+ * @since : 2024-01-19
+ */
+@Getter
+public enum Role {
+    ROLE_MEMBER, ROLE_ARTEST, ROLE_LIARTEST, ROLE_ADMIN, ROLE_GUEST;
+}

--- a/src/main/java/com/livarter/app/dto/MemberResDto.java
+++ b/src/main/java/com/livarter/app/dto/MemberResDto.java
@@ -1,0 +1,56 @@
+package com.livarter.app.dto;
+
+import com.livarter.app.domain.Member;
+import com.livarter.app.domain.enumType.Grade;
+import com.livarter.app.domain.enumType.Role;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * @author : 황수영
+ * @fileName : MemberResDto
+ * @since : 2024-01-20
+ */
+@Getter
+@NoArgsConstructor
+public class MemberResDto {
+
+    private String email;
+    private String nickname;
+    private Role role;
+    private String image;
+    private Grade grade;
+
+    private String name;
+    private String address;
+    private String zipCode;
+    private LocalDate birthDate;
+
+    private int curPoint;
+    private int totalPoint;
+    private LocalDate createdAt;
+    private LocalDate updatedAt;
+
+    public static MemberResDto of(Member member) {
+        MemberResDto memberResDto = new MemberResDto();
+        memberResDto.email = member.getEmail();
+        memberResDto.nickname = member.getNickname();
+        memberResDto.role = member.getRole();
+        memberResDto.image = member.getImage();
+        memberResDto.grade = member.getGrade();
+
+        memberResDto.name = member.getName();
+        memberResDto.address = member.getAddress();
+        memberResDto.zipCode = member.getZipCode();
+        memberResDto.birthDate = member.getBirthDate();
+
+        memberResDto.curPoint = member.getCurPoint();
+        memberResDto.totalPoint = member.getTotalPoint();
+        memberResDto.createdAt = member.getCreatedAt();
+        memberResDto.updatedAt = member.getUpdatedAt();
+
+        return memberResDto;
+    }
+}

--- a/src/main/java/com/livarter/app/mapper/MemberMapper.java
+++ b/src/main/java/com/livarter/app/mapper/MemberMapper.java
@@ -1,6 +1,10 @@
 package com.livarter.app.mapper;
 
+import com.livarter.app.domain.Member;
 
 public interface MemberMapper {
-
+    void saveMember(Member member);
+    Member findById(int id);
+    Member findByEmail(String email);
+    void updateRefreshToken(Member member);
 }

--- a/src/main/java/com/livarter/app/security/AuthDetailsService.java
+++ b/src/main/java/com/livarter/app/security/AuthDetailsService.java
@@ -1,0 +1,46 @@
+package com.livarter.app.security;
+
+import com.livarter.app.domain.Member;
+import com.livarter.app.mapper.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author : 황수영
+ * @fileName : CustomDetailsService
+ * @since : 2024-01-19
+ */
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class AuthDetailsService implements UserDetailsService {
+
+    private final MemberMapper memberMapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Member member = memberMapper.findById(Integer.parseInt(id));
+        log.debug("loadUserByUsername() => member : " + member);
+        return createUserDetails(member);
+    }
+
+    private UserDetails createUserDetails(Member member) {
+        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
+
+        return new User(
+                String.valueOf(member.getId()),
+                String.valueOf(member.getId()),
+                grantedAuthorities);
+    }
+}

--- a/src/main/java/com/livarter/app/security/AuthTokenAccessDeniedHandler.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.livarter.app.security;
+
+import lombok.extern.log4j.Log4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author : 황수영
+ * @fileName : AuthTokenAccessDeniedHandler
+ * @since : 2024-01-19
+ */
+@Log4j
+@Component
+public class AuthTokenAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        log.debug("AuthTokenAccessDeniedHandler : 인가되지 않은 사용자의 요청");
+
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/com/livarter/app/security/AuthTokenAuthenticationEntryPoint.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.livarter.app.security;
+
+import lombok.extern.log4j.Log4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author : 황수영
+ * @fileName : AuthTokenAuthenticationEntryPoint
+ * @since : 2024-01-19
+ */
+@Log4j
+@Component
+public class AuthTokenAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        log.debug("AuthTokenAuthenticationEntryPoint : 인증되지 않은 사용자의 요청");
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/livarter/app/security/AuthTokenFilter.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenFilter.java
@@ -1,0 +1,52 @@
+package com.livarter.app.security;
+
+import com.livarter.app.domain.enumType.Header;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author : 황수영
+ * @fileName : AuthTokenFilter
+ * @since : 2024-01-19
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthTokenFilter extends OncePerRequestFilter {
+
+    private final AuthTokenGenerator authTokenGenerator;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            String accessToken = resolveToken(request);
+            authTokenGenerator.isTokenValidate(accessToken);
+            Authentication authentication = authTokenGenerator.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (Exception e) {
+            log.debug("AuthTokenFilter : accessToken 토큰이 유효하지 않습니다.");
+            throw new RuntimeException(e);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Header.AUTH.getValue());
+        if (bearerToken != null && bearerToken.startsWith(Header.BEARER.getValue())) {
+            return bearerToken.substring(Header.BEARER.getValue().length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/livarter/app/security/AuthTokenFilterConfigurer.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenFilterConfigurer.java
@@ -1,0 +1,32 @@
+package com.livarter.app.security;
+
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author : 황수영
+ * @fileName : AuthTokenFilterConfigurer
+ * @since : 2024-01-19
+ */
+@Log4j
+@Component
+public class AuthTokenFilterConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
+    public AuthTokenFilterConfigurer(AuthTokenGenerator authTokenGenerator) {
+        this.authTokenGenerator = authTokenGenerator;
+    }
+
+    @Override
+    public void configure(HttpSecurity httpSecurity) {
+        AuthTokenFilter customFilter = new AuthTokenFilter(authTokenGenerator);
+        httpSecurity.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/livarter/app/security/AuthTokenFilterConfigurer.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenFilterConfigurer.java
@@ -1,7 +1,7 @@
 package com.livarter.app.security;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
@@ -15,14 +15,10 @@ import org.springframework.stereotype.Component;
  */
 @Log4j
 @Component
+@RequiredArgsConstructor
 public class AuthTokenFilterConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
-    @Autowired
-    private AuthTokenGenerator authTokenGenerator;
-
-    public AuthTokenFilterConfigurer(AuthTokenGenerator authTokenGenerator) {
-        this.authTokenGenerator = authTokenGenerator;
-    }
+    private final AuthTokenGenerator authTokenGenerator;
 
     @Override
     public void configure(HttpSecurity httpSecurity) {

--- a/src/main/java/com/livarter/app/security/AuthTokenGenerator.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenGenerator.java
@@ -27,13 +27,10 @@ public class AuthTokenGenerator implements InitializingBean {
 
     @Value("${jwt.access-validity}")
     private long accessValidity;
-
     @Value("${jwt.refresh-validity}")
     private long refreshValidity;
-
     @Value("${jwt.secret}")
     private String jwtSecret;
-
     private final AuthDetailsService authDetailsService;
 
     @Override

--- a/src/main/java/com/livarter/app/security/AuthTokenGenerator.java
+++ b/src/main/java/com/livarter/app/security/AuthTokenGenerator.java
@@ -1,0 +1,96 @@
+package com.livarter.app.security;
+
+import com.livarter.app.domain.enumType.Header;
+import com.livarter.app.security.dto.LoginResDto;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * @author : 황수영
+ * @fileName : AuthTokenProvider
+ * @since : 2024-01-19
+ */
+@Log4j
+@Component
+@RequiredArgsConstructor
+public class AuthTokenGenerator implements InitializingBean {
+
+    @Value("${jwt.access-validity}")
+    private long accessValidity;
+
+    @Value("${jwt.refresh-validity}")
+    private long refreshValidity;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    private final AuthDetailsService authDetailsService;
+
+    @Override
+    public void afterPropertiesSet() {
+        jwtSecret = Base64.getEncoder().encodeToString(jwtSecret.getBytes());
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = getClaims(accessToken);
+        UserDetails userDetails = authDetailsService.loadUserByUsername(claims.getSubject());
+        log.debug("AuthTokenGenerator getAuthentication() userDetails : " + userDetails);
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, accessToken, userDetails.getAuthorities());
+    }
+
+    public LoginResDto createLoginResDto(String id) {
+        String accessToken = createJwtToken(id, accessValidity);
+        String refreshToken = createJwtToken(id, refreshValidity);
+
+        return LoginResDto.builder()
+                .accessToken(Header.BEARER.getValue() + accessToken)
+                .refreshToken(Header.BEARER.getValue() + refreshToken)
+                .build();
+    }
+
+    public String createJwtToken(String id, long validity) {
+        Date now = new Date();
+        Claims claims = Jwts.claims()
+                .setSubject(id);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .setExpiration(new Date(now.getTime() + validity))
+                .compact();
+    }
+
+    public Claims getClaims(String accessToken) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(jwtSecret)
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public void isTokenValidate(String token) throws Exception {
+        try {
+            Jwts.parser()
+                .setSigningKey(jwtSecret)
+                .parseClaimsJws(token);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new Exception();
+        }
+    }
+}

--- a/src/main/java/com/livarter/app/security/KakaoOauthClient.java
+++ b/src/main/java/com/livarter/app/security/KakaoOauthClient.java
@@ -1,0 +1,61 @@
+package com.livarter.app.security;
+
+import com.livarter.app.domain.enumType.Header;
+import com.livarter.app.security.dto.KakaoResDto;
+import com.livarter.app.security.dto.LoginReqDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author : 황수영
+ * @fileName : KakaoOauthClient
+ * @since : 2024-01-20
+ */
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthClient {
+
+    @Value("${oauth.kakao.request-uri}")
+    private String reqUri;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String getEmail(LoginReqDto loginRequestDto) {
+        KakaoResDto kakaoResDto = getUserInfoByLoginToken(loginRequestDto.getLoginToken());
+        return kakaoResDto.getEmail();
+    }
+
+    private KakaoResDto getUserInfoByLoginToken(String accessToken) {
+        log.info("getUserInfoByLoginToken() - accessToken : " + accessToken);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(Header.AUTH.getValue(), Header.BEARER.getValue() + accessToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        return getOAuthInfo(request);
+    }
+
+    private KakaoResDto getOAuthInfo(HttpEntity<MultiValueMap<String, String>> request) {
+        KakaoResDto kakaoResDto = null;
+        try {
+            kakaoResDto = restTemplate.postForObject(reqUri, request, KakaoResDto.class);
+            log.debug("kakaoResDto : " + kakaoResDto);
+        } catch(HttpClientErrorException e) {
+            log.error("HttpClientErrorException : " + e.getResponseBodyAsString());
+        } catch(HttpServerErrorException e) {
+            log.error("HttpServerErrorException : " + e.getResponseBodyAsString());
+        } catch(Exception e) {
+            log.error("Exception : " + e);
+        }
+        return kakaoResDto;
+    }
+}

--- a/src/main/java/com/livarter/app/security/SecurityWebApplicationInitializer.java
+++ b/src/main/java/com/livarter/app/security/SecurityWebApplicationInitializer.java
@@ -1,0 +1,11 @@
+package com.livarter.app.security;
+
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+
+/**
+ * @author : 황수영
+ * @fileName : SecurityWebApplicationInitializer
+ * @since : 2024-01-19
+ */
+public class SecurityWebApplicationInitializer extends AbstractSecurityWebApplicationInitializer {
+}

--- a/src/main/java/com/livarter/app/security/dto/KakaoResDto.java
+++ b/src/main/java/com/livarter/app/security/dto/KakaoResDto.java
@@ -1,0 +1,35 @@
+package com.livarter.app.security.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/**
+ * @author : 황수영
+ * @fileName : KakaoResDto
+ * @since : 2024-01-20
+ */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoResDto {
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoAccount {
+        private KakaoProfile profile;
+        private String email;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoProfile {
+        private String nickname;
+    }
+
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+}

--- a/src/main/java/com/livarter/app/security/dto/LoginReqDto.java
+++ b/src/main/java/com/livarter/app/security/dto/LoginReqDto.java
@@ -1,0 +1,15 @@
+package com.livarter.app.security.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author : 황수영
+ * @fileName : LoginReqDto
+ * @since : 2024-01-19
+ */
+@Getter
+@Setter
+public class LoginReqDto {
+    private String loginToken;
+}

--- a/src/main/java/com/livarter/app/security/dto/LoginResDto.java
+++ b/src/main/java/com/livarter/app/security/dto/LoginResDto.java
@@ -1,0 +1,20 @@
+package com.livarter.app.security.dto;
+
+import lombok.*;
+
+/**
+ * @author : 황수영
+ * @fileName : TokenDto
+ * @since : 2024-01-19
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginResDto {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/livarter/app/service/MemberService.java
+++ b/src/main/java/com/livarter/app/service/MemberService.java
@@ -1,7 +1,85 @@
 package com.livarter.app.service;
 
+import com.livarter.app.domain.Member;
+import com.livarter.app.domain.enumType.Grade;
+import com.livarter.app.domain.enumType.Nickname;
+import com.livarter.app.domain.enumType.Role;
+import com.livarter.app.dto.MemberResDto;
+import com.livarter.app.mapper.MemberMapper;
+import com.livarter.app.security.AuthTokenGenerator;
+import com.livarter.app.security.KakaoOauthClient;
+import com.livarter.app.security.dto.LoginReqDto;
+import com.livarter.app.security.dto.LoginResDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
 /**
  * @author : 황수영
  * @fileName : MemberService
- * @since : 2024-01-20
+ * @since : 2024-01-19
  */
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    @Value("${jwt.access-validity}")
+    private long accessValidity;
+
+    private final MemberMapper memberMapper;
+    private final KakaoOauthClient oAuthClient;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    public MemberResDto getMember(String id) {
+        Member member = memberMapper.findById(Integer.parseInt(id));
+        return MemberResDto.of(member);
+    }
+
+    public LoginResDto login(LoginReqDto loginReqDto) {
+        String email = oAuthClient.getEmail(loginReqDto);
+
+        Member findMember = memberMapper.findByEmail(email);
+        if (findMember != null) {
+            return getUpdatedToken(findMember);
+        }
+        return joinByEmail(email);
+    }
+
+    private String updateAccessToken(Member member) {
+        String memberId = String.valueOf(member.getId());
+        return authTokenGenerator.createJwtToken(memberId, accessValidity);
+    }
+
+    private LoginResDto getUpdatedToken(Member member) {
+        String newAccessToken = updateAccessToken(member);
+        String refreshToken = member.getRefreshToken();
+
+        return LoginResDto.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public LoginResDto joinByEmail(String email) {
+        Member member = Member.builder()
+                .email(email)
+                .nickname(Nickname.getRandomNickname())
+                .role(Role.ROLE_MEMBER)
+                .grade(Grade.BEGINNER)
+                .build();
+        memberMapper.saveMember(member);
+
+        Member savedMember = memberMapper.findByEmail(email);
+        int memberId = savedMember.getId();
+
+        LoginResDto loginResDto = authTokenGenerator.createLoginResDto(String.valueOf(memberId));
+        savedMember.updateRefreshToken(loginResDto.getRefreshToken());
+        memberMapper.updateRefreshToken(savedMember);
+
+        log.trace("joinByEmail savedMember" + savedMember);
+        return loginResDto;
+    }
+
+}

--- a/src/main/java/com/livarter/app/service/MemberService.java
+++ b/src/main/java/com/livarter/app/service/MemberService.java
@@ -2,6 +2,7 @@ package com.livarter.app.service;
 
 import com.livarter.app.domain.Member;
 import com.livarter.app.domain.enumType.Grade;
+import com.livarter.app.domain.enumType.Header;
 import com.livarter.app.domain.enumType.Nickname;
 import com.livarter.app.domain.enumType.Role;
 import com.livarter.app.dto.MemberResDto;
@@ -57,7 +58,7 @@ public class MemberService {
         String refreshToken = member.getRefreshToken();
 
         return LoginResDto.builder()
-                .accessToken(newAccessToken)
+                .accessToken(Header.BEARER.getValue() + newAccessToken)
                 .refreshToken(refreshToken)
                 .build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+database.username=${DB_USERNAME}
+database.password=${DB_PASSWORD}
+database.url=${DB_URL}
+jwt.auth-header=${JWT_AUTH_HEADER}
+jwt.bearer-header=${JWT_BEARER_HEADER}
+jwt.secret=${JWT_SECRET}
+jwt.access-validity=${JWT_ACCESS_VALIDITY}
+jwt.refresh-validity=${JWT_REFRESH_VALIDITY}
+oauth.kakao.request-uri=${REQUEST_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,0 @@
-database:
-  username: ${DB_USERNAME}
-  password: ${DB_PASSWORD}
-  url: ${DB_URL}

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -3,4 +3,65 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.livarter.app.mapper.MemberMapper">
 
+    <insert id="saveMember" parameterType="com.livarter.app.domain.Member" >
+        INSERT INTO member ( id
+                           , email
+                           , nickname
+                           , role
+                           , grade
+        )
+        VALUES ( member_id_seq.nextval
+               , #{email}
+               , #{nickname}
+               , #{role, typeHandler=com.livarter.app.config.DatabaseEnumTypeHandler}
+               , #{grade, typeHandler=com.livarter.app.config.DatabaseEnumTypeHandler}
+               )
+    </insert>
+
+    <select id="findById" resultType="com.livarter.app.domain.Member" >
+        SELECT   id AS id
+               , email AS email
+               , nickname AS nickname
+               , role AS role
+               , image AS image
+               , refresh_token AS refreshToken
+               , grade AS grade
+               , name AS name
+               , address AS address
+               , zip_code AS zipCode
+               , birth_date AS birthDate
+               , cur_point AS curPoint
+               , total_point AS totalPoint
+               , created_at AS createdAt
+               , updated_at AS updatedAt
+        FROM   MEMBER
+        WHERE  id = #{id}
+    </select>
+
+    <select id="findByEmail" resultType="com.livarter.app.domain.Member" >
+        SELECT id AS id
+             , email AS email
+             , nickname AS nickname
+             , role AS role
+             , image AS image
+             , refresh_token AS refreshToken
+             , grade AS grade
+             , name AS name
+             , address AS address
+             , zip_code AS zipCode
+             , birth_date AS birthDate
+             , cur_point AS curPoint
+             , total_point AS totalPoint
+             , created_at AS createdAt
+             , updated_at AS updatedAt
+        FROM   MEMBER
+        WHERE  email = #{email}
+    </select>
+
+    <update id="updateRefreshToken" parameterType="com.livarter.app.domain.Member">
+        UPDATE MEMBER
+        SET refresh_token = #{refreshToken}
+        WHERE id = #{id}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## ✨ 과제 내용
- #1 
- Security 설정
- Kakao 로그인 후 이메일 받아서 회원 가입
- JWT 로직 구현
- 회원 가입
- 회원 정보 조회

## 📸 스크린샷

<img width="1053" alt="image" src="https://github.com/livarter/backend/assets/77563814/37ce5d8d-d2fb-414d-a0f2-0ad215a39c52">

<img width="771" alt="image" src="https://github.com/livarter/backend/assets/77563814/0d9f2427-3832-4684-9dbc-78e44991f5e7">


## 📚 참고사항
- **이후에 회원 관련 API는 모두 Authorization 헤더에 Access Token을 담아서 요청해야 합니다**~!
  -  => Security 필터로 인증/인가 처리 진행
- **회원 키값은 Oracle 시퀀스 사용**
- **회원 도메인 일부 추가 및 수정**
  - birthDate/refreshToken 추가
  - 닉네임은 랜덤 닉네임 자동 생성
  - [날짜 타입 Date 대신 LocalDate 통일하는 거 어떨까욥..?](https://sowon-dev.github.io/2020/08/05/200806javai/)
  - 카카오에서 사업자 번호 없이는 이메일/닉네임/프로필 이미지만 받을 수 있어서
    나머지 정보는 이후 추가 입력하는 방식으로 변경
  - Java에서 Enum 타입 -> Oracle에서 String으로 저장되도록 핸들러 설정 (댓글 참고)
  
  +) 일단 로컬 DB에서 작업했습니당